### PR TITLE
Async-radius.

### DIFF
--- a/sample/main.cpp
+++ b/sample/main.cpp
@@ -80,9 +80,9 @@ int main(int argc, char* argv[])
 
     try
     {
-        boost::asio::io_service io_service;
-        Server server(io_service, secret, port, "/usr/share/freeradius/dictionary");
-        io_service.run();
+        boost::asio::io_context io_context;
+        Server server(io_context, secret, port, "/usr/share/freeradius/dictionary");
+        io_context.run();
     }
     catch (const std::exception& e)
     {

--- a/sample/server.cpp
+++ b/sample/server.cpp
@@ -6,8 +6,8 @@
 
 using boost::system::error_code;
 
-Server::Server(boost::asio::io_service& io_service, const std::string& secret, uint16_t port, const std::string& filePath)
-    : m_radius(io_service, secret, port),
+Server::Server(boost::asio::io_context& io_context, const std::string& secret, uint16_t port, const std::string& filePath)
+    : m_radius(io_context, secret, port),
       m_dictionaries(filePath)
 {
     startReceive();

--- a/sample/server.h
+++ b/sample/server.h
@@ -10,7 +10,7 @@
 class Server
 {
     public:
-        Server(boost::asio::io_service& io_service, const std::string& secret, uint16_t port, const std::string& filePath);
+        Server(boost::asio::io_context& io_context, const std::string& secret, uint16_t port, const std::string& filePath);
 
     private:
         RadProto::Packet makeResponse(const RadProto::Packet& request);


### PR DESCRIPTION
All uses of io_service replaced by io_context in the catalog sample.