### PR TITLE
Async Radius.

### DIFF
--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -2,7 +2,7 @@
 #include "attribute.h"
 #include "utils.h"
 #include "error.h"
-#include <openssl/md5.h>
+#include <openssl/evp.h>
 #include <algorithm>
 #include <iostream>
 
@@ -140,8 +140,10 @@ Encrypted::Encrypted(uint8_t type, const uint8_t* data, size_t size, const std::
     for (size_t i = 0; i < size / 16; ++i)
     {
         std::array<uint8_t, 16> md;
+        unsigned mdSize = md.size();
 
-        MD5(mdBuffer.data(), mdBuffer.size(), md.data());
+        EVP_Digest(mdBuffer.data(), mdBuffer.size(), md.data(), &mdSize, EVP_md5(), nullptr);
+
         for (size_t j = 0; j < 16; ++j)
             plaintext[i * 16 + j] = data[i * 16 + j] ^ md[j];
 
@@ -181,7 +183,9 @@ std::vector<uint8_t> Encrypted::toVector(const std::string& secret, const std::a
     for (size_t i = 0; i < plaintext.length() / 16; ++i)
     {
         std::array<uint8_t, 16> md;
-        MD5(mdBuffer.data(), mdBuffer.size(), md.data());
+        unsigned mdSize = md.size();
+
+        EVP_Digest(mdBuffer.data(), mdBuffer.size(), md.data(), &mdSize, EVP_md5(), nullptr);
 
         for (size_t j = 0; j < md.size(); ++j)
             *it++ = plaintext[i * 16 + j] ^ md[j];

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -1,7 +1,7 @@
 #include "packet.h"
 #include "error.h"
 #include "attribute_types.h"
-#include <openssl/md5.h>
+#include <openssl/evp.h>
 #include <stdexcept>
 
 using Packet = RadProto::Packet;
@@ -132,7 +132,9 @@ const std::vector<uint8_t> Packet::makeSendBuffer(const std::string& secret) con
             sendBuffer[i + sendBuffer.size() - secret.length()] = secret[i];
 
         std::array<uint8_t, 16> md;
-        MD5(sendBuffer.data(), sendBuffer.size(), md.data());
+        unsigned mdSize = md.size();
+
+        EVP_Digest(sendBuffer.data(), sendBuffer.size(), md.data(), &mdSize, EVP_md5(), nullptr);
 
         sendBuffer.resize(sendBuffer.size() - secret.length());
 

--- a/tests/socket_tests.cpp
+++ b/tests/socket_tests.cpp
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(TestAsyncSend)
 
     boost::asio::io_context io_context;
 
-    boost::asio::ip::udp::endpoint destination(boost::asio::ip::address_v4::from_string("127.0.0.1"), 3000);
+    boost::asio::ip::udp::endpoint destination(boost::asio::ip::make_address_v4("127.0.0.1"), 3000);
 
     RadProto::Socket s(io_context, "secret", 3000);
 


### PR DESCRIPTION
Deprecated MD5 function replaced by EVP_Digests in packet.cpp, attribute.cpp. Deprecated boost::asio::ip::address_v4::from_string replaced by boost::asio::ip::address_v4::make_address_v4 in socket_tests.cpp.